### PR TITLE
Fix for GetNumberOfDigitsAfterDecimal and DigitsAfterDecimal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bin/
 *.suo
 *.nupkg
 project.lock.json
+.cr/
+.vs/
+UpgradeLog.htm

--- a/PluralNet.Shared/Utils/DecimalExt.cs
+++ b/PluralNet.Shared/Utils/DecimalExt.cs
@@ -2,9 +2,11 @@
  * Huyn.PluralNet
  * Author  Rudy Huyn (6Studio)
  * License MIT / http://bit.ly/mit-license
- * 
+ *
  * Version 1.00
  */
+
+using System;
 
 namespace Huyn.PluralNet.Utils
 {
@@ -26,7 +28,11 @@ namespace Huyn.PluralNet.Utils
 
         public static uint GetNumberOfDigitsAfterDecimal(this decimal number)
         {
-            return (uint)((number - (int)number).ToString()).Length - 2;
+            var text = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var decpoint = text.IndexOf('.');
+            if (decpoint < 0)
+                return 0;
+            return (uint)(text.Length - decpoint - 1);
         }
 
 
@@ -34,9 +40,12 @@ namespace Huyn.PluralNet.Utils
         {
             try
             {
-                //need optimization
-                var str = ((number - (int)number).ToString()).Substring(2);
-                if (str == "")
+                var text = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var decpoint = text.IndexOf('.');
+                if (decpoint < 0)
+                    return 0;
+                var str = text.Substring(decpoint + 1);
+                if (str == String.Empty)
                     return 0;
                 return long.Parse(str);
             }

--- a/PluralNet.sln
+++ b/PluralNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "PluralNet.Shared", "PluralNet.Shared\PluralNet.Shared.shproj", "{1CEE422A-F0FC-4D54-B606-5F942C8F6159}"
 EndProject
@@ -13,14 +13,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralNet.Silverlight", "Pl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralNet.Portable", "PluralNet.Portable\PluralNet.Portable.csproj", "{9601B867-0732-4DDA-9C75-E0653E4D5A58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluralNet.xUnitTest", "PluralNet.xUnitTest\PluralNet.xUnitTest.csproj", "{4788D011-5964-4F70-A1A9-CB9B0A184B5D}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		PluralNet.Shared\PluralNet.Shared.projitems*{1cee422a-f0fc-4d54-b606-5f942c8f6159}*SharedItemsImports = 13
-		PluralNet.Shared\PluralNet.Shared.projitems*{26c68eeb-b24a-4bcf-943a-a46c3e76a144}*SharedItemsImports = 4
-		PluralNet.Shared\PluralNet.Shared.projitems*{9601b867-0732-4dda-9c75-e0653e4d5a58}*SharedItemsImports = 4
-		PluralNet.Shared\PluralNet.Shared.projitems*{f0ce0fcd-9784-4999-afab-e411d61f65fc}*SharedItemsImports = 4
-		PluralNet.Shared\PluralNet.Shared.projitems*{ff419b3f-9dea-4597-8124-39acfd467af7}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
@@ -96,8 +91,31 @@ Global
 		{9601B867-0732-4DDA-9C75-E0653E4D5A58}.Release|x64.Build.0 = Release|Any CPU
 		{9601B867-0732-4DDA-9C75-E0653E4D5A58}.Release|x86.ActiveCfg = Release|Any CPU
 		{9601B867-0732-4DDA-9C75-E0653E4D5A58}.Release|x86.Build.0 = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|x64.Build.0 = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Debug|x86.Build.0 = Debug|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|ARM.Build.0 = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|x64.ActiveCfg = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|x64.Build.0 = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|x86.ActiveCfg = Release|Any CPU
+		{4788D011-5964-4F70-A1A9-CB9B0A184B5D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		PluralNet.Shared\PluralNet.Shared.projitems*{1cee422a-f0fc-4d54-b606-5f942c8f6159}*SharedItemsImports = 13
+		PluralNet.Shared\PluralNet.Shared.projitems*{26c68eeb-b24a-4bcf-943a-a46c3e76a144}*SharedItemsImports = 4
+		PluralNet.Shared\PluralNet.Shared.projitems*{9601b867-0732-4dda-9c75-e0653e4d5a58}*SharedItemsImports = 4
+		PluralNet.Shared\PluralNet.Shared.projitems*{f0ce0fcd-9784-4999-afab-e411d61f65fc}*SharedItemsImports = 4
+		PluralNet.Shared\PluralNet.Shared.projitems*{ff419b3f-9dea-4597-8124-39acfd467af7}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/PluralNet.xUnitTest/PluralNet.xUnitTest.csproj
+++ b/PluralNet.xUnitTest/PluralNet.xUnitTest.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluralNet.Portable\PluralNet.Portable.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PluralNet.xUnitTest/Usings.cs
+++ b/PluralNet.xUnitTest/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/PluralNet.xUnitTest/Utils/TestDecimalExt.cs
+++ b/PluralNet.xUnitTest/Utils/TestDecimalExt.cs
@@ -1,0 +1,117 @@
+using Huyn.PluralNet.Utils;
+
+namespace PluralNet.Core.Test.Utils
+{
+    public class TestDecimalExt
+    {
+        [Theory]
+        [InlineData("1", "1", "5")]
+        [InlineData("3", "1", "5")]
+        [InlineData("3.5", "1", "5")]
+        [InlineData("5", "1", "5")]
+        public void IsBetween(string s, string s1, string s2)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            decimal start = Decimal.Parse(s1, System.Globalization.CultureInfo.InvariantCulture);
+            decimal end = Decimal.Parse(s2, System.Globalization.CultureInfo.InvariantCulture);
+
+            Assert.True(number.IsBetween(start, end));
+        }
+
+        [Theory]
+        [InlineData("0", "1", "5")]
+        [InlineData("0.999", "1", "5")]
+        [InlineData("5.01", "1", "5")]
+        [InlineData("6", "1", "5")]
+        public void IsNotBetween(string s, string s1, string s2)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            decimal start = Decimal.Parse(s1, System.Globalization.CultureInfo.InvariantCulture);
+            decimal end = Decimal.Parse(s2, System.Globalization.CultureInfo.InvariantCulture);
+
+            Assert.False(number.IsBetween(start, end));
+        }
+
+        [Theory]
+        [InlineData("1", "1", "5")]
+        [InlineData("3", "1", "5")]
+        [InlineData("3.5", "1", "5")]
+        public void IsBetweenEndNotIncluded(string s, string s1, string s2)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            decimal start = Decimal.Parse(s1, System.Globalization.CultureInfo.InvariantCulture);
+            decimal end = Decimal.Parse(s2, System.Globalization.CultureInfo.InvariantCulture);
+
+            Assert.True(number.IsBetweenEndNotIncluded(start, end));
+        }
+
+        [Theory]
+        [InlineData("0", "1", "5")]
+        [InlineData("0.999", "1", "5")]
+        [InlineData("5", "1", "5")]
+        [InlineData("5.01", "1", "5")]
+        [InlineData("6", "1", "5")]
+        public void IsNotBetweenEndNotIncluded(string s, string s1, string s2)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            decimal start = Decimal.Parse(s1, System.Globalization.CultureInfo.InvariantCulture);
+            decimal end = Decimal.Parse(s2, System.Globalization.CultureInfo.InvariantCulture);
+
+            Assert.False(number.IsBetweenEndNotIncluded(start, end));
+        }
+
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("3")]
+        [InlineData("-3")]
+        public void IsInt(string s)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.True(((decimal)number).IsInt());
+        }
+
+        [Theory]
+        [InlineData("0.999")]
+        [InlineData("5.01")]
+        [InlineData("-0.999")]
+        public void IsNotInt(string s)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.False(((decimal)number).IsInt());
+        }
+
+        [Theory]
+        [InlineData("0", 0)]
+        [InlineData("1", 0)]
+        [InlineData("3", 0)]
+        [InlineData("-3", 0)]
+        [InlineData("0.999", 3)]
+        [InlineData("5.00", 2)]
+        [InlineData("5.01", 2)]
+        [InlineData("-0.999", 3)]
+        [InlineData("-5.999", 3)]
+        public void GetNumberOfDigitsAfterDecimal(string s, uint expected)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Equal(expected, number.GetNumberOfDigitsAfterDecimal());
+        }
+
+        [Theory]
+        [InlineData("0", 0)]
+        [InlineData("1", 0)]
+        [InlineData("3", 0)]
+        [InlineData("-3", 0)]
+        [InlineData("0.999", 999)]
+        [InlineData("5.01", 1)]
+        [InlineData("-0.999", 999)]
+        [InlineData("-5.999", 999)]
+        public void DigitsAfterDecimal(string s, long expected)
+        {
+            decimal number = Decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Equal(expected, number.DigitsAfterDecimal());
+        }
+
+    }
+}


### PR DESCRIPTION
DecimalExt.GetNumberOfDigitsAfterDecimal and DecimalExt.DigitsAfterDecimal failed on negative numbers. Fix for both methods and added xUnit tests for DecimalExt. So I have to modify .gitignore to add .vs and .cr folders to exclusions.